### PR TITLE
Feat-option-to-ignore-prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 # vendor/
 
 dist/
+tmp/

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ If you have uncommitted changes then you can build a snapshot with the following
 just release-snapshot
 ```
 
-### Running it local
+### Running it locally
 
 You can start the project locally by running:
 
@@ -130,4 +130,10 @@ Then send a request to the local service using curl.
 curl http://127.0.0.1:9000/register \
     -X POST \
     --data '{"name":"mychild","supportedOperations":["c8y_Firmware"]}' -H "Content-Type: application/json"
+```
+
+Example output:
+
+```sh
+{"name":"mychild","id":"mychild","parent":"main001"}
 ```

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ The following flags are supported.
         Port (default 9000)
   --separator string
         Device name separator (default "_")
+  --use-prefix
+        Prefix the child id with the main device id (default true)
   --version
         Show version information
 ```
@@ -97,6 +99,7 @@ Alternatively the values for the flags can be provided via environment variables
 |`--bind`|`REGISTRATION_BIND`|
 |`--port`|`REGISTRATION_PORT`|
 |`--separator`|`REGISTRATION_SEPARATOR`|
+|`--use-prefix=<true|false>`|`REGISTRATION_USE_PREFIX`|
 
 ### Building
 
@@ -110,4 +113,21 @@ If you have uncommitted changes then you can build a snapshot with the following
 
 ```sh
 just release-snapshot
+```
+
+### Running it local
+
+You can start the project locally by running:
+
+```sh
+mkdir -p tmp/operations/c8y
+go run main.go --use-prefix=false --device-id main001 --config-dir tmp
+```
+
+Then send a request to the local service using curl.
+
+```sh
+curl http://127.0.0.1:9000/register \
+    -X POST \
+    --data '{"name":"mychild","supportedOperations":["c8y_Firmware"]}' -H "Content-Type: application/json"
 ```


### PR DESCRIPTION
feat: support flag/setting to disable prefixing child devices with the main device.

**Example**

```sh
mkdir -p tmp/operations/c8y
go run main.go --use-prefix=false --device-id main001 --config-dir tmp
```

Then send a request to the local service using curl.

```sh
curl http://127.0.0.1:9000/register \
    -X POST \
    --data '{"name":"mychild","supportedOperations":["c8y_Firmware"]}' -H "Content-Type: application/json"
```

Example output:

```sh
{"name":"mychild","id":"mychild","parent":"main001"}
```